### PR TITLE
Fix filename matcher for Chase Credit statements

### DIFF
--- a/beancount_chase/credit.py
+++ b/beancount_chase/credit.py
@@ -14,7 +14,7 @@ _COLUMN_DATE = 'Transaction Date'
 _COLUMN_PAYEE = 'Description'
 _COLUMN_AMOUNT = 'Amount'
 
-_FILENAME_PATTERN = re.compile(r'Chase(\d{4})_Activity([\d]+_)+[\d]+.CSV',
+_FILENAME_PATTERN = re.compile(r'Chase(\d{4})_Activity([\d]+_)*[\d]+.CSV',
                                re.IGNORECASE)
 
 

--- a/beancount_chase/credit_test.py
+++ b/beancount_chase/credit_test.py
@@ -30,6 +30,20 @@ def test_identifies_chase_credit_file(tmp_path):
                               lastfour='1234').identify(f)
 
 
+def test_identifies_chase_credit_file_first_statement(tmp_path):
+    """The first statement in an account has a shorter filename."""
+    chase_file = tmp_path / 'Chase1234_Activity20220720.CSV'
+    chase_file.write_text(
+        _unindent("""
+            Card,Transaction Date,Post Date,Description,Category,Type,Amount,Memo
+            1234,01/06/2021,01/07/2021,AMZN Mktp US,Shopping,Sale,-20.54,
+            """))
+
+    with chase_file.open() as f:
+        assert CreditImporter(account='Liabilities:Credit-Cards:Chase',
+                              lastfour='1234').identify(f)
+
+
 def test_extracts_spend(tmp_path):
     chase_file = tmp_path / 'Chase1234_Activity20210103_20210202_20210214.CSV'
     chase_file.write_text(


### PR DESCRIPTION
The first statement on a new card has a different filename format.

Fixes #31 