### PR TITLE
Actually finish conversion to Beancount 3

### DIFF
--- a/beancount_chase/checking.py
+++ b/beancount_chase/checking.py
@@ -47,16 +47,16 @@ class CheckingImporter(beangulp.Importer):
         return self._account
 
     def identify(self, filepath):
-        match = _FILENAME_PATTERN.match(os.path.basename(filepath.name))
+        match = _FILENAME_PATTERN.match(os.path.basename(filepath))
         if not match:
             return False
         return self._last_four_account_digits == match.group(1)
 
-    def extract(self, file):
+    def extract(self, filepath):
         transactions = []
 
-        for index, row in enumerate(csv.DictReader(file)):
-            metadata = data.new_metadata(file.name, index)
+        for index, row in enumerate(csv.DictReader(filepath)):
+            metadata = data.new_metadata(filepath, index)
             transaction = self._extract_transaction_from_row(row, metadata)
             if not transaction:
                 continue

--- a/beancount_chase/checking.py
+++ b/beancount_chase/checking.py
@@ -41,7 +41,7 @@ class CheckingImporter(beangulp.Importer):
         return amount.Amount(beancount_number.D(amount_raw), self._currency)
 
     def date(self, filepath):
-        return max(map(lambda x: x.date, self.extract(filepath)))
+        return max(map(lambda x: x.date, self.extract(filepath, [])))
 
     def account(self, _):
         return self._account
@@ -52,7 +52,7 @@ class CheckingImporter(beangulp.Importer):
             return False
         return self._last_four_account_digits == match.group(1)
 
-    def extract(self, filepath):
+    def extract(self, filepath, _existing):
         transactions = []
 
         for index, row in enumerate(csv.DictReader(filepath)):

--- a/beancount_chase/checking.py
+++ b/beancount_chase/checking.py
@@ -55,12 +55,13 @@ class CheckingImporter(beangulp.Importer):
     def extract(self, filepath, _existing):
         transactions = []
 
-        for index, row in enumerate(csv.DictReader(filepath)):
-            metadata = data.new_metadata(filepath, index)
-            transaction = self._extract_transaction_from_row(row, metadata)
-            if not transaction:
-                continue
-            transactions.append(transaction)
+        with open(filepath, encoding='utf-8') as csv_file:
+            for index, row in enumerate(csv.DictReader(csv_file)):
+                metadata = data.new_metadata(filepath, index)
+                transaction = self._extract_transaction_from_row(row, metadata)
+                if not transaction:
+                    continue
+                transactions.append(transaction)
 
         return transactions
 

--- a/beancount_chase/checking_test.py
+++ b/beancount_chase/checking_test.py
@@ -40,7 +40,7 @@ def test_extracts_outbound_transfer(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2021-09-13 * "Schwab Personal Checking ########9876" "Online Transfer 12345678901 to Schwab Personal Checking ########9876 Transaction #: 12345678901 09/13"
@@ -58,7 +58,7 @@ def test_extracts_same_day_ach_transaction(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2024-05-24 * "JoeExample" "Same-Day ACH Payment 12232800456 to JoeExample (_######9587)"
@@ -77,7 +77,7 @@ def test_extracts_standard_ach_transaction(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2024-11-06 * "JaneExample" "Online ACH Payment 12232800456 to JaneExample (_######9587)"
@@ -98,7 +98,7 @@ def test_extracts_monthly_account_fee(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2023-08-31 * "Monthly Service Fee" ""
@@ -116,7 +116,7 @@ def test_extracts_monthly_account_fee_refund(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2024-02-01 * "Monthly Service Fee Reversal January 2024" ""
@@ -134,7 +134,7 @@ def test_extracts_monthly_account_fee_refund_2(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2025-04-18 * "Fee Reversal" ""
@@ -152,7 +152,7 @@ def test_extracts_real_time_payment_fee(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2024-06-03 * "RTP/Same Day - Low Value" ""
@@ -170,7 +170,7 @@ def test_extracts_foreign_exchange_wire_fee(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2025-01-27 * "Online Foreign Exchange International Wire Fee" ""
@@ -188,7 +188,7 @@ def test_extracts_international_wire_transfer(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2025-01-27 * "Online International Wire Transfer a/C: Foreign Cur Bus Acct Bk 1 Columbus Newark De 197132352 Us Org: 00000000252697135 John Q Name Ben:/De98850554080404114242 Globo Chem Ref: Supply Order Business Expenses/Ocmt/Eur100,00/Exch/0.9246/Cn Tr/61323361/ Trn: 1359400013re 01/27" ""
@@ -207,7 +207,7 @@ def test_doesnt_title_case_if_asked_not_to(tmp_path):
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
                                       lastfour='1234',
-                                      title_case=False).extract(f)
+                                      title_case=False).extract(f, [])
 
     assert _unindent("""
         2023-08-31 * "MONTHLY SERVICE FEE" ""
@@ -225,7 +225,7 @@ def test_extracts_credit(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2021-09-03 * "gumroad.com" "Gumroad"
@@ -243,7 +243,7 @@ def test_extracts_debit_card_transaction(tmp_path):
 
     with chase_file.open() as f:
         directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f)
+                                      lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2025-01-05 * "Spotify" ""
@@ -266,7 +266,7 @@ def test_matches_account_when_pattern_splits_across_payee_and_narration(
                                       account_patterns=[
                                           ('Chase Credit CRD.*Autopaybus',
                                            'Liabilities:Credit-Cards:Chase')
-                                      ]).extract(f)
+                                      ]).extract(f, [])
 
     assert _unindent("""
         2021-11-06 * "Chase Credit CRD" "Autopaybus"

--- a/beancount_chase/checking_test.py
+++ b/beancount_chase/checking_test.py
@@ -26,9 +26,8 @@ def test_identifies_chase_file(tmp_path):
             DEBIT,09/13/2021,"Online Transfer 12582403448 to Schwab Personal Checking ########1078 transaction #: 12582403448 09/13",-2500.00,ACCT_XFER,4325.75,,
             """))
 
-    with chase_file.open() as f:
-        assert CheckingImporter(account='Assets:Checking:Chase',
-                                lastfour='1234').identify(f)
+    assert CheckingImporter(account='Assets:Checking:Chase',
+                            lastfour='1234').identify(chase_file)
 
 
 def test_extracts_outbound_transfer(tmp_path):

--- a/beancount_chase/checking_test.py
+++ b/beancount_chase/checking_test.py
@@ -38,9 +38,8 @@ def test_extracts_outbound_transfer(tmp_path):
             DEBIT,09/13/2021,"Online Transfer 12345678901 to Schwab Personal Checking ########9876 transaction #: 12345678901 09/13",-2500.00,ACCT_XFER,4325.75,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2021-09-13 * "Schwab Personal Checking ########9876" "Online Transfer 12345678901 to Schwab Personal Checking ########9876 Transaction #: 12345678901 09/13"
@@ -56,9 +55,8 @@ def test_extracts_same_day_ach_transaction(tmp_path):
             DEBIT,05/24/2024,"Same-Day ACH Payment 12232800456 to JoeExample (_######9587)",-87.50,ACH_PAYMENT,6788.52,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2024-05-24 * "JoeExample" "Same-Day ACH Payment 12232800456 to JoeExample (_######9587)"
@@ -75,9 +73,8 @@ def test_extracts_standard_ach_transaction(tmp_path):
             DEBIT,12/02/2024,"STANDARD ACH PMNTS INITIAL FEE",-2.50,FEE_TRANSACTION,4552.60,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2024-11-06 * "JaneExample" "Online ACH Payment 12232800456 to JaneExample (_######9587)"
@@ -96,9 +93,8 @@ def test_extracts_monthly_account_fee(tmp_path):
             DEBIT,08/31/2023,"MONTHLY SERVICE FEE",-15.00,FEE_TRANSACTION,2118.39,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2023-08-31 * "Monthly Service Fee" ""
@@ -114,9 +110,8 @@ def test_extracts_monthly_account_fee_refund(tmp_path):
             CREDIT,02/01/2024,"Monthly Service Fee Reversal January 2024",15.00,REFUND_TRANSACTION,2521.99,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2024-02-01 * "Monthly Service Fee Reversal January 2024" ""
@@ -132,9 +127,8 @@ def test_extracts_monthly_account_fee_refund_2(tmp_path):
             CREDIT,04/18/2025,"FEE REVERSAL",15.00,REFUND_TRANSACTION,2544.21,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2025-04-18 * "Fee Reversal" ""
@@ -150,9 +144,8 @@ def test_extracts_real_time_payment_fee(tmp_path):
             DEBIT,06/03/2024,"RTP/Same Day - Low Value",-1.75,FEE_TRANSACTION,6786.77,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2024-06-03 * "RTP/Same Day - Low Value" ""
@@ -168,9 +161,8 @@ def test_extracts_foreign_exchange_wire_fee(tmp_path):
             DEBIT,01/27/2025,"ONLINE FX INTERNATIONAL WIRE FEE",-5.00,FEE_TRANSACTION,5088.02,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2025-01-27 * "Online Foreign Exchange International Wire Fee" ""
@@ -186,9 +178,8 @@ def test_extracts_international_wire_transfer(tmp_path):
             DEBIT,01/27/2025,"ONLINE INTERNATIONAL WIRE TRANSFER A/C: FOREIGN CUR BUS ACCT BK 1 COLUMBUS NEWARK DE 197132352 US ORG: 00000000252697135 JOHN Q NAME BEN:/DE98850554080404114242 GLOBO CHEM REF: SUPPLY ORDER BUSINESS EXPENSES/OCMT/EUR100,00/EXCH/0.9246/CN TR/61323361/ TRN: 1359400013RE 01/27",-108.15,WIRE_OUTGOING,5008.02,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2025-01-27 * "Online International Wire Transfer a/C: Foreign Cur Bus Acct Bk 1 Columbus Newark De 197132352 Us Org: 00000000252697135 John Q Name Ben:/De98850554080404114242 Globo Chem Ref: Supply Order Business Expenses/Ocmt/Eur100,00/Exch/0.9246/Cn Tr/61323361/ Trn: 1359400013re 01/27" ""
@@ -204,10 +195,9 @@ def test_doesnt_title_case_if_asked_not_to(tmp_path):
             DEBIT,08/31/2023,"MONTHLY SERVICE FEE",-15.00,FEE_TRANSACTION,2118.39,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234',
-                                      title_case=False).extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234',
+                                  title_case=False).extract(chase_file, [])
 
     assert _unindent("""
         2023-08-31 * "MONTHLY SERVICE FEE" ""
@@ -223,9 +213,8 @@ def test_extracts_credit(tmp_path):
             CREDIT,09/03/2021,"ORIG CO NAME:gumroad.com            ORIG ID:1234567890 DESC DATE:       CO ENTRY DESCR:Gumroad   SEC:CCD    TRACE#:987654321987654 EED:112233   IND ID:ST-JAABBCCDDEEF              IND NAME:MICHAEL CUSTOMER TRN: 1122334455TC",63.84,ACH_CREDIT,7687.53,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2021-09-03 * "gumroad.com" "Gumroad"
@@ -241,9 +230,8 @@ def test_extracts_debit_card_transaction(tmp_path):
             DEBIT,01/05/2025,"Spotify",-10.00,DEBIT_CARD,1000.00,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234').extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2025-01-05 * "Spotify" ""
@@ -260,13 +248,12 @@ def test_matches_account_when_pattern_splits_across_payee_and_narration(
             DEBIT,11/06/2021,"ORIG CO NAME:CHASE CREDIT CRD       ORIG ID:1234567890 DESC DATE:211203 CO ENTRY DESCR:AUTOPAYBUSSEC:PPD    TRACE#:987654321987654 EED:112233   IND ID:                             IND NAME:MICHAEL CUSTOMER T TRN: 1122334455TC",-357.51,ACH_DEBIT,2988.62,,
             """))
 
-    with chase_file.open() as f:
-        directives = CheckingImporter(account='Assets:Checking:Chase',
-                                      lastfour='1234',
-                                      account_patterns=[
-                                          ('Chase Credit CRD.*Autopaybus',
-                                           'Liabilities:Credit-Cards:Chase')
-                                      ]).extract(f, [])
+    directives = CheckingImporter(account='Assets:Checking:Chase',
+                                  lastfour='1234',
+                                  account_patterns=[
+                                      ('Chase Credit CRD.*Autopaybus',
+                                       'Liabilities:Credit-Cards:Chase')
+                                  ]).extract(chase_file, [])
 
     assert _unindent("""
         2021-11-06 * "Chase Credit CRD" "Autopaybus"

--- a/beancount_chase/credit.py
+++ b/beancount_chase/credit.py
@@ -40,7 +40,7 @@ class CreditImporter(beangulp.Importer):
         return amount.Amount(beancount_number.D(amount_raw), self._currency)
 
     def date(self, filepath):
-        return max(map(lambda x: x.date, self.extract(filepath)))
+        return max(map(lambda x: x.date, self.extract(filepath, [])))
 
     def account(self, _):
         return self._account
@@ -51,7 +51,7 @@ class CreditImporter(beangulp.Importer):
             return False
         return self._last_four_account_digits == match.group(1)
 
-    def extract(self, filepath):
+    def extract(self, filepath, _existing):
         transactions = []
 
         for index, row in enumerate(csv.DictReader(filepath)):

--- a/beancount_chase/credit.py
+++ b/beancount_chase/credit.py
@@ -46,16 +46,16 @@ class CreditImporter(beangulp.Importer):
         return self._account
 
     def identify(self, filepath):
-        match = _FILENAME_PATTERN.match(os.path.basename(filepath.name))
+        match = _FILENAME_PATTERN.match(os.path.basename(filepath))
         if not match:
             return False
         return self._last_four_account_digits == match.group(1)
 
-    def extract(self, file):
+    def extract(self, filepath):
         transactions = []
 
-        for index, row in enumerate(csv.DictReader(file)):
-            metadata = data.new_metadata(file.name, index)
+        for index, row in enumerate(csv.DictReader(filepath)):
+            metadata = data.new_metadata(filepath, index)
             transaction = self._extract_transaction_from_row(row, metadata)
             if not transaction:
                 continue

--- a/beancount_chase/credit.py
+++ b/beancount_chase/credit.py
@@ -54,12 +54,13 @@ class CreditImporter(beangulp.Importer):
     def extract(self, filepath, _existing):
         transactions = []
 
-        for index, row in enumerate(csv.DictReader(filepath)):
-            metadata = data.new_metadata(filepath, index)
-            transaction = self._extract_transaction_from_row(row, metadata)
-            if not transaction:
-                continue
-            transactions.append(transaction)
+        with open(filepath, encoding='utf-8') as csv_file:
+            for index, row in enumerate(csv.DictReader(csv_file)):
+                metadata = data.new_metadata(filepath, index)
+                transaction = self._extract_transaction_from_row(row, metadata)
+                if not transaction:
+                    continue
+                transactions.append(transaction)
 
         return transactions
 

--- a/beancount_chase/credit_test.py
+++ b/beancount_chase/credit_test.py
@@ -51,9 +51,8 @@ def test_extracts_spend(tmp_path):
             1234,10/29/2021,10/31/2021,GOOGLE *CLOUD_02BB66-C,Professional Services,Sale,-25.35,
             """))
 
-    with chase_file.open() as f:
-        directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                                    lastfour='1234').extract(f, [])
+    directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
+                                lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2021-10-29 * "Google *Cloud_02bb66-C"
@@ -69,14 +68,12 @@ def test_extracts_spend_with_matching_transaction(tmp_path):
             1234,10/29/2021,10/31/2021,GOOGLE *CLOUD_02BB66-C,Professional Services,Sale,-25.35,
             """))
 
-    with chase_file.open() as f:
-        directives = CreditImporter(
-            account='Liabilities:Credit-Cards:Chase',
-            lastfour='1234',
-            account_patterns=[
-                ('Google.*Cloud',
-                 'Expenses:Cloud-Services:Google-Cloud-Platform'),
-            ]).extract(f, [])
+    directives = CreditImporter(
+        account='Liabilities:Credit-Cards:Chase',
+        lastfour='1234',
+        account_patterns=[
+            ('Google.*Cloud', 'Expenses:Cloud-Services:Google-Cloud-Platform'),
+        ]).extract(chase_file, [])
 
     assert _unindent("""
         2021-10-29 * "Google *Cloud_02bb66-C"
@@ -93,15 +90,13 @@ def test_doesnt_title_case_if_asked_not_to(tmp_path):
             1234,10/29/2021,10/31/2021,GOOGLE *CLOUD_02BB66-C,Professional Services,Sale,-25.35,
             """))
 
-    with chase_file.open() as f:
-        directives = CreditImporter(
-            account='Liabilities:Credit-Cards:Chase',
-            lastfour='1234',
-            account_patterns=[
-                ('Google.*Cloud',
-                 'Expenses:Cloud-Services:Google-Cloud-Platform'),
-            ],
-            title_case=False).extract(f, [])
+    directives = CreditImporter(
+        account='Liabilities:Credit-Cards:Chase',
+        lastfour='1234',
+        account_patterns=[
+            ('Google.*Cloud', 'Expenses:Cloud-Services:Google-Cloud-Platform'),
+        ],
+        title_case=False).extract(chase_file, [])
 
     assert _unindent("""
         2021-10-29 * "GOOGLE *CLOUD_02BB66-C"
@@ -118,9 +113,8 @@ def test_extracts_refund(tmp_path):
             1234,01/06/2021,01/07/2021,AMZN Mktp US,Shopping,Return,413.54,
             """))
 
-    with chase_file.open() as f:
-        directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                                    lastfour='1234').extract(f, [])
+    directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
+                                lastfour='1234').extract(chase_file, [])
 
     assert _unindent("""
         2021-01-06 * "AMZN MKTP US"
@@ -136,13 +130,12 @@ def test_extracts_payment(tmp_path):
             1234,11/04/2021,11/04/2021,Payment Thank You - Web,,Payment,4000.00,
             """))
 
-    with chase_file.open() as f:
-        directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                                    lastfour='1234',
-                                    account_patterns=[
-                                        ('Payment Thank You',
-                                         'Assets:Checking:Bank-of-America')
-                                    ]).extract(f, [])
+    directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
+                                lastfour='1234',
+                                account_patterns=[
+                                    ('Payment Thank You',
+                                     'Assets:Checking:Bank-of-America')
+                                ]).extract(chase_file, [])
 
     assert _unindent("""
         2021-11-04 * "Payment Thank You - Web"

--- a/beancount_chase/credit_test.py
+++ b/beancount_chase/credit_test.py
@@ -53,7 +53,7 @@ def test_extracts_spend(tmp_path):
 
     with chase_file.open() as f:
         directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                                    lastfour='1234').extract(f)
+                                    lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2021-10-29 * "Google *Cloud_02bb66-C"
@@ -76,7 +76,7 @@ def test_extracts_spend_with_matching_transaction(tmp_path):
             account_patterns=[
                 ('Google.*Cloud',
                  'Expenses:Cloud-Services:Google-Cloud-Platform'),
-            ]).extract(f)
+            ]).extract(f, [])
 
     assert _unindent("""
         2021-10-29 * "Google *Cloud_02bb66-C"
@@ -101,7 +101,7 @@ def test_doesnt_title_case_if_asked_not_to(tmp_path):
                 ('Google.*Cloud',
                  'Expenses:Cloud-Services:Google-Cloud-Platform'),
             ],
-            title_case=False).extract(f)
+            title_case=False).extract(f, [])
 
     assert _unindent("""
         2021-10-29 * "GOOGLE *CLOUD_02BB66-C"
@@ -120,7 +120,7 @@ def test_extracts_refund(tmp_path):
 
     with chase_file.open() as f:
         directives = CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                                    lastfour='1234').extract(f)
+                                    lastfour='1234').extract(f, [])
 
     assert _unindent("""
         2021-01-06 * "AMZN MKTP US"
@@ -142,7 +142,7 @@ def test_extracts_payment(tmp_path):
                                     account_patterns=[
                                         ('Payment Thank You',
                                          'Assets:Checking:Bank-of-America')
-                                    ]).extract(f)
+                                    ]).extract(f, [])
 
     assert _unindent("""
         2021-11-04 * "Payment Thank You - Web"

--- a/beancount_chase/credit_test.py
+++ b/beancount_chase/credit_test.py
@@ -26,9 +26,8 @@ def test_identifies_chase_credit_file(tmp_path):
             1234,01/06/2021,01/07/2021,AMZN Mktp US,Shopping,Sale,-20.54,
             """))
 
-    with chase_file.open() as f:
-        assert CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                              lastfour='1234').identify(f)
+    assert CreditImporter(account='Liabilities:Credit-Cards:Chase',
+                          lastfour='1234').identify(chase_file)
 
 
 def test_identifies_chase_credit_file_first_statement(tmp_path):
@@ -40,9 +39,8 @@ def test_identifies_chase_credit_file_first_statement(tmp_path):
             1234,01/06/2021,01/07/2021,AMZN Mktp US,Shopping,Sale,-20.54,
             """))
 
-    with chase_file.open() as f:
-        assert CreditImporter(account='Liabilities:Credit-Cards:Chase',
-                              lastfour='1234').identify(f)
+    assert CreditImporter(account='Liabilities:Credit-Cards:Chase',
+                          lastfour='1234').identify(chase_file)
 
 
 def test_extracts_spend(tmp_path):


### PR DESCRIPTION
Apologies—I thought I had pulled my own changes into my environment before sending them, but it turns out I was still mistakenly using the Beancount 2 version. After I updated to 5abf9dd, the importer blew up.

I'm certain now that I fixed everything:
```
<journals dir> ❯ git -C ~/src/BEANS/chase rev-parse HEAD
b800cc541322d58e804080e087f6a57c93d4afd2
<journals dir> ❯ PYTHONPATH=~/src/BEANS/chase:$PYTHONPATH python -m importinator extract download/Chase<redacted>.CSV -e main.beancount | head -7
* <redacted>/download/Chase<redacted>.CSV ... OK
;; -*- mode: beancount -*-

**** <redacted>/download/Chase<redacted>.CSV

; duplicate of <redacted>/<redacted>.beancount
; 2025-<redacted> * "CLIPPER SERVICES"
;   Liabilities:Chase  <redacted>
```